### PR TITLE
implement GatePtr NullPointerException

### DIFF
--- a/qulacs/gate/gate.hpp
+++ b/qulacs/gate/gate.hpp
@@ -57,7 +57,12 @@ public:
     template <GateImpl U>
     GatePtr(const GatePtr<U>& gate) : GatePtr(gate._gate_ptr) {}
 
-    T* operator->() const { return _gate_ptr.get(); }
+    T* operator->() const {
+        if (!_gate_ptr) {
+            throw std::runtime_error("GatePtr::operator->(): Gate is Null");
+        }
+        return _gate_ptr.get();
+    }
 };
 }  // namespace internal
 


### PR DESCRIPTION
close #48 
0でないが無効な場所を指すポインタを意図的に作られた場合（例: `Gate gate(std::shared_ptr<internal::XGateImpl>((internal::XGateImpl*)10000));`）はどうしてもキャッチできませんが、単に後で代入する予定で`Gate gate`と宣言して使ってしまった場合にわかりやすく例外が出るようにしました。