### PR TITLE
User interface

### DIFF
--- a/qulacs/types.hpp
+++ b/qulacs/types.hpp
@@ -6,7 +6,11 @@
 
 namespace qulacs {
 
-inline void initialize() { Kokkos::initialize(); }
+using InitializationSettings = Kokkos::InitializationSettings;
+
+inline void initialize(const InitializationSettings& settings = InitializationSettings()) {
+    Kokkos::initialize(settings);
+}
 inline void finalize() { Kokkos::finalize(); }
 
 using UINT = std::uint64_t;

--- a/qulacs/types.hpp
+++ b/qulacs/types.hpp
@@ -5,6 +5,10 @@
 #include <cstdint>
 
 namespace qulacs {
+
+inline void initialize() { Kokkos::initialize(); }
+inline void finalize() { Kokkos::finalize(); }
+
 using UINT = std::uint64_t;
 
 using Complex = Kokkos::complex<double>;


### PR DESCRIPTION
ユーザに Kokkos のメソッドを触らせるのは嫌なので、以下のように qulacs のメソッドとして使えるようにラップしました。
```cpp
int main(void) {
  qulacs::InitializationSettings settings;
  settings.set_num_threads(8);
  qulacs::initialize(settings);

  // your codes

  qulacs::finalize();
}
```